### PR TITLE
Fix three code bugs

### DIFF
--- a/src/core/virtual-object-pool.h
+++ b/src/core/virtual-object-pool.h
@@ -78,7 +78,7 @@ public:
         }
         auto freeListNode = freeListHead;
         FreeListNode* prevFreeNode = nullptr;
-        while (freeListNode && freeListNode->Offset < offset + size)
+        while (freeListNode && freeListNode->Offset < offset)
         {
             prevFreeNode = freeListNode;
             freeListNode = freeListNode->next;

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -668,7 +668,9 @@ Result SLANG_MCALL getD3D11Adapters(std::vector<AdapterInfo>& outAdapters)
         dxgiAdapter->GetDesc(&desc);
         AdapterInfo info = {};
         auto name = string::from_wstring(desc.Description);
-        memcpy(info.name, name.data(), min(name.size(), sizeof(AdapterInfo::name) - 1));
+        size_t nameLen = min(name.size(), sizeof(AdapterInfo::name) - 1);
+        memcpy(info.name, name.data(), nameLen);
+        info.name[nameLen] = '\0';  // Ensure null termination
         info.vendorID = desc.VendorId;
         info.deviceID = desc.DeviceId;
         info.luid = getAdapterLUID(dxgiAdapter);

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1961,7 +1961,9 @@ Result SLANG_MCALL getD3D12Adapters(std::vector<AdapterInfo>& outAdapters)
         dxgiAdapter->GetDesc(&desc);
         AdapterInfo info = {};
         auto name = string::from_wstring(desc.Description);
-        memcpy(info.name, name.data(), min(name.length(), sizeof(AdapterInfo::name) - 1));
+        size_t nameLen = min(name.length(), sizeof(AdapterInfo::name) - 1);
+        memcpy(info.name, name.data(), nameLen);
+        info.name[nameLen] = '\0';  // Ensure null termination
         info.vendorID = desc.VendorId;
         info.deviceID = desc.DeviceId;
         info.luid = getAdapterLUID(dxgiAdapter);

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -374,7 +374,9 @@ Result SLANG_MCALL getMetalAdapters(std::vector<AdapterInfo>& outAdapters)
     {
         AdapterInfo info = {};
         const char* name = device->name()->cString(NS::ASCIIStringEncoding);
-        memcpy(info.name, name, min(strlen(name), sizeof(AdapterInfo::name) - 1));
+        size_t nameLen = min(strlen(name), sizeof(AdapterInfo::name) - 1);
+        memcpy(info.name, name, nameLen);
+        info.name[nameLen] = '\0';  // Ensure null termination
         uint64_t registryID = device->registryID();
         memcpy(&info.luid.luid[0], &registryID, sizeof(registryID));
         outAdapters.push_back(info);

--- a/src/shader-object.cpp
+++ b/src/shader-object.cpp
@@ -67,7 +67,12 @@ Result ShaderObject::setData(const ShaderOffset& offset, const void* data, Size 
     // that are too large, but we have several test cases that set more data than
     // an object actually stores on several targets...
     //
-    if ((dataOffset + dataSize) >= availableSize)
+    if (dataOffset >= availableSize)
+    {
+        // Offset is beyond buffer bounds, skip the write entirely
+        return SLANG_OK;
+    }
+    if ((dataOffset + dataSize) > availableSize)
     {
         dataSize = availableSize - dataOffset;
     }

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1920,7 +1920,9 @@ Result SLANG_MCALL getVKAdapters(std::vector<AdapterInfo>& outAdapters)
                 VkPhysicalDeviceProperties props;
                 api.vkGetPhysicalDeviceProperties(physicalDevice, &props);
                 AdapterInfo info = {};
-                memcpy(info.name, props.deviceName, min(strlen(props.deviceName), sizeof(AdapterInfo::name) - 1));
+                size_t nameLen = min(strlen(props.deviceName), sizeof(AdapterInfo::name) - 1);
+                memcpy(info.name, props.deviceName, nameLen);
+                info.name[nameLen] = '\0';  // Ensure null termination
                 info.vendorID = props.vendorID;
                 info.deviceID = props.deviceID;
                 info.luid = vk::getAdapterLUID(api, physicalDevice);


### PR DESCRIPTION
Addresses an integer underflow in shader object bounds checking, corrects virtual object pool free list insertion, and ensures null termination for adapter names to improve memory safety and correctness.

---
<a href="https://cursor.com/background-agent?bcId=bc-33015e4a-015f-4654-8172-4f0fe96bfbf8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-33015e4a-015f-4654-8172-4f0fe96bfbf8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

